### PR TITLE
real encryption key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "serial_test",
  "sled",
  "tempfile",
+ "xdg",
 ]
 
 [[package]]
@@ -1048,6 +1049,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
+
+[[package]]
+name = "xdg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ rand_core = "0.9.3"
 serial_test = "3.2.0"
 sled = "0.34.7"
 tempfile = "3.19.1"
+xdg = "3.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"


### PR DESCRIPTION
Before, we were using a dummy key. But obviously that's not safe, so here we start using a real key. We read it from `$XDG_CONFIG_HOM/dotsec/private/dotsec.key` if the path exists. If not, we create that file and place the key there!

We'll document this in the README once it gets added but I'll put it here also: Protecting the key file is considered out of scope for this tool. `dotsec`'s main goal is to provide a safe way to store secrets. It's on the user to safely store their key. Other tools don't regulate what the user does with their password/key, and `dotsec` is similar in that way.

This will close #3 